### PR TITLE
fixes get_object where the unique ID field is not 'Name'

### DIFF
--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -22,10 +22,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
+
 from eppy.idfreader import idfreader1
 from eppy.idfreader import makeabunch
+
 import eppy.function_helpers as function_helpers
-import copy
+
+
 
 class NoObjectError(Exception):
     """Exception Object"""
@@ -163,11 +167,13 @@ def addobject1(bunchdt, data, commdct, key, **kwargs):
 
 def getobject(bunchdt, key, name):
     """get the object if you have the key and the name
-    retunrs a list of objects, in case you have more than one
+    returns a list of objects, in case you have more than one
     You should not have more than one"""
-    # TODO : throw exception if more than one object, or return more objects
-    idfobjects = bunchdt[key]
-    theobjs = [idfobj for idfobj in idfobjects if idfobj.Name.upper() == name.upper()]
+    # TODO : throw exception if more than one object, or return more objects    idfobjects = bunchdt[key]
+    if idfobjects:
+        uniqueID = idfobjects[0].objls[1] # second item in list is a unique ID
+    theobjs = [idfobj for idfobj in idfobjects if
+               idfobj[uniqueID].upper() == name.upper()]
     try:
         return theobjs[0]
     except IndexError:

--- a/eppy/snippet.py
+++ b/eppy/snippet.py
@@ -147,5 +147,12 @@ BuildingSurface:Detailed,
     30.5,0.0,2.4,  !- X,Y,Z ==> Vertex 3 {m}
     30.5,0.0,3.0;  !- X,Y,Z ==> Vertex 4 {m}
 
+ZoneHVAC:EquipmentConnections,
+    SPACE1-1,                   !- Zone Name
+    AnEquipmentList,            !- Zone Conditioning Equipment List Name
+    AnAirInletNode,             !- Zone Air Inlet Node or NodeList Name
+    AnExhaustNode,              !- Zone Air Exhaust Node or NodeList Name
+    AZoneAirNode,               !- Zone Air Node Name
+    AZoneReturnAirNode;         !- Zone Return Air Node Name
 """
 

--- a/eppy/tests/test_modeleditor.py
+++ b/eppy/tests/test_modeleditor.py
@@ -22,28 +22,30 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import pytest
-from eppy.pytest_helpers import almostequal
+from StringIO import StringIO
 
+from eppy.iddcurrent import iddcurrent
+from eppy.iddcurrent import iddcurrent
+from eppy.modeleditor import IDF
+from eppy.pytest_helpers import almostequal
 import bunch
+import pytest
+
 import eppy.idfreader as idfreader
 import eppy.modeleditor as modeleditor
 import eppy.snippet as snippet
-from eppy.modeleditor import IDF
 
-from eppy.iddcurrent import iddcurrent
+
 iddsnippet = iddcurrent.iddtxt
 
 idfsnippet = snippet.idfsnippet
 
-from StringIO import StringIO
 idffhandle = StringIO(idfsnippet)
 iddfhandle = StringIO(iddsnippet)
 bunchdt, data, commdct = idfreader.idfreader(idffhandle, iddfhandle)
 
 # idd is read only once in this test
 # if it has already been read from some other test, it will continue with the old reading
-from eppy.iddcurrent import iddcurrent
 iddfhandle = StringIO(iddcurrent.iddtxt)
 if IDF.getiddname() == None:
     IDF.setiddname(iddfhandle)
@@ -170,6 +172,8 @@ def test_getobject():
         ('ZONE', 'PLENUM-1', bunchdt['ZONE'][0]), # key, name, theobject
         ('ZONE', 'PLENUM-1'.lower(), bunchdt['ZONE'][0]), # key, name, theobject
         ('ZONE', 'PLENUM-A', None), # key, name, theobject
+        ('ZONEHVAC:EQUIPMENTCONNECTIONS', 'SPACE1-1',
+            bunchdt['ZONEHVAC:EQUIPMENTCONNECTIONS'][0]), # key, name, theobject
     )
     for key, name, theobject in thedata:
         result = modeleditor.getobject(bunchdt, key, name)


### PR DESCRIPTION
added zone HVAC equipment connections to eppy.snippet, added test for get_object where the unique ID field is not 'Name', test passes