### PR TITLE
Don't raise Exception when resetting to same IDD file, just pass

### DIFF
--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -451,6 +451,8 @@ class IDF0(object):
             cls.iddname = arg
             cls.idd_info = None
             cls.block = None
+        elif cls.iddname == arg:
+            pass
         else:
             if testing == False:
                 errortxt = "IDD file is set to: %s"  % (cls.iddname, )


### PR DESCRIPTION
This avoids raising an Exception when resetting the IDD file for the case when the same IDD file is used. It's convenient for using eppy in an IPython Notebook.