### PR TITLE
Basic unicode support for IDF4

### DIFF
--- a/eppy/bunch_subclass.py
+++ b/eppy/bunch_subclass.py
@@ -73,19 +73,19 @@ class EpBunch_1(Bunch):
             raise BadEPFieldError(astr)
     def __repr__(self):
         """print this as an idf snippet"""
-        lines = [str(val) for val in self.obj]
-        comments = [comm.replace('_', ' ') for comm in self.objls]
-        lines[0] = "%s," % (lines[0], ) # comma after first line
+        lines = [unicode(val) for val in self.obj]
+        comments = [comm.replace(u'_', u' ') for comm in self.objls]
+        lines[0] = u"%s," % (lines[0], ) # comma after first line
         for i, line in enumerate(lines[1:-1]):
-            lines[i + 1] = '    %s,' % (line, ) # indent and comma
-        lines[-1] = '    %s;' % (lines[-1], )# ';' after last line
+            lines[i + 1] = u'    %s,' % (line, ) # indent and comma
+        lines[-1] = u'    %s;' % (lines[-1], )# ';' after last line
         lines = [line.ljust(26) for line in lines] # ljsut the lines
-        filler = '%s    !- %s'
+        filler = u'%s    !- %s'
         nlines = [filler % (line, comm) for line,
                   comm in zip(lines[1:], comments[1:])]# adds comments to line
         nlines.insert(0, lines[0])# first line without comment
-        astr = '\n'.join(nlines)
-        return '\n%s\n' % (astr, )
+        astr = u'\n'.join(nlines)
+        return u'\n%s\n' % (astr, )
 
 class EpBunch_2(EpBunch_1):
     """Has data, aliases in bunch"""

--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -667,14 +667,14 @@ class IDF4(IDF3):
         if lineendings == 'default':
             pass
         elif lineendings == 'windows':
-            s = '!- Windows Line endings \n' + s
+            s = u'!- Windows Line endings \n' + s
             slines = s.splitlines()
-            s = '\r\n'.join(slines)
+            s = u'\r\n'.join(slines)
         elif lineendings == 'unix':
-            s = '!- Unix Line endings \n' + s
+            s = u'!- Unix Line endings \n' + s
             slines = s.splitlines()
-            s = '\n'.join(slines)
-        open(filename, 'w').write(s)
+            s = u'\n'.join(slines)
+        open(filename, 'w').write(s.encode('utf-8')
     def saveas(self, filename, lineendings='default'):
         self.idfname = filename
         self.save(lineendings=lineendings)


### PR DESCRIPTION
This branch adds basic unicode support to IDF files. At this moment this means supporting field data and writing support just for IDF4 models.