### PR TITLE
Set up continuous integration with Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ __pycache__
 .pydevproject
 .settings/
 /remove_licence.py
+# Travis CI
+build/
+dist/
+*.egg-info
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-# platforms
-os:
-  - linux
-  - osx
+
+matrix:
+    include:
+        - os: linux
+          sudo: required
+          python: 2.7
+          env: TRAVIS_OS_NAME=linux
+        - os: linux
+          sudo: required
+          python: 3.3
+          env: TRAVIS_OS_NAME=linux
+        - os: osx
+          python: 2.7
+          env: TRAVIS_OS_NAME=osx
+        - os: osx
+          python: 3.3
+          env: TRAVIS_OS_NAME=osx
 # install EnergyPlus
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh etEPlusV830-lin.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
     env: TRAVIS_OS_NAME=linux
 
 # install EnergyPlus
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh -O EPlus-inst.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x EPlus-inst.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./EPlus-inst.sh
+#before_install:
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh -O EPlus-inst.sh
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x EPlus-inst.sh
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./EPlus-inst.sh
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,29 @@
 language: python
 
 matrix:
-    include:
-        - os: linux
-          sudo: required
-          python: 2.7
-          env: TRAVIS_OS_NAME=linux
-        - os: linux
-          sudo: required
-          python: 3.3
-          env: TRAVIS_OS_NAME=linux
-        - os: osx
-          python: 2.7
-          env: TRAVIS_OS_NAME=osx
-        - os: osx
-          python: 3.3
-          env: TRAVIS_OS_NAME=osx
+  include:
+  - os: linux
+    python: 2.7
+    env: TRAVIS_OS_NAME=linux
+  - os: linux
+    python: 3.3
+    env: TRAVIS_OS_NAME=linux
+  - os: osx
+    python: 2.7
+    env: TRAVIS_OS_NAME=osx
+  - os: osx
+    python: 3.3
+    env: TRAVIS_OS_NAME=osx
 # install EnergyPlus
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh etEPlusV830-lin.sh
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x etEPlusV830-lin.sh
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod +x etEPlusV830-lin.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x etEPlusV830-lin.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod +x etEPlusV830-lin.sh
 
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo sudo hdiutil attach EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo installer -package /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.pkg -target /
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; sudo hdiutil detach /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo sudo hdiutil attach EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo installer -package /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.pkg -target /
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; sudo hdiutil detach /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,18 @@ python:
 # platforms
 os:
   - linux
-#  - osx
-#  - windows
+  - osx
 # install EnergyPlus
 before_install:
-  - wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh
-  - sudo EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh etEPlusV830-lin.sh
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x etEPlusV830-lin.sh
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod +x etEPlusV830-lin.sh
+
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo sudo hdiutil attach EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo installer -package /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.pkg -target /
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; sudo hdiutil detach /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64
+
 # command to install dependencies
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script: py.test
+# whitelist
+branches:
+  only:
+    - travis_trial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+# command to install dependencies
+install:
+  - pip install .
+  - pip install -r requirements.txt
+# command to run tests
+script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,19 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+# platforms
+os:
+  - linux
+  - osx
+  - windows
 # command to install dependencies
 install:
   - pip install .
   - pip install -r requirements.txt
-# command to run tests
-script: py.test
 # whitelist
 branches:
   only:
     - travis_trial
+# command to run tests
+script: py.test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,12 @@ matrix:
   - os: linux
     python: 3.3
     env: TRAVIS_OS_NAME=linux
-  - os: osx
-    python: 2.7
-    env: TRAVIS_OS_NAME=osx
-  - os: osx
-    python: 3.3
-    env: TRAVIS_OS_NAME=osx
+
 # install EnergyPlus
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh etEPlusV830-lin.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x etEPlusV830-lin.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo chmod +x etEPlusV830-lin.sh
-
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo sudo hdiutil attach EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.dmg
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo installer -package /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64.pkg -target /
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; sudo hdiutil detach /Volumes/EnergyPlus-8.4.0-09f5359d8a-Darwin-x86_64
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh -O EPlus-inst.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x EPlus-inst.sh
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ./EPlus-inst.sh
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ python:
 # platforms
 os:
   - linux
-  - osx
-  - windows
+#  - osx
+#  - windows
+# install EnergyPlus
+before_install:
+  - wget https://github.com/NREL/EnergyPlus/releases/download/v8.4.0-Update1/EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh
+  - sudo EnergyPlus-8.4.0-09f5359d8a-Linux-x86_64.sh
 # command to install dependencies
 install:
   - pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-bunch>=1.0
-beautifulsoup4>=4.2.1
-numpy>=1.7.1
-pydot>1.0
-pyparsing==1.5.7
-pytest>=2.3.5
+beautifulsoup4==4.4.1
+bunch==1.0.1
+eppy==0.5
+numpy==1.10.4
+py==1.4.31
+pydot==1.0.2
+pyparsing==2.0.7
+pytest==2.8.5
+wheel==0.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 beautifulsoup4==4.4.1
 bunch==1.0.1
-eppy==0.5
 numpy==1.10.4
 py==1.4.31
 pydot==1.0.2


### PR DESCRIPTION
I've recently been committing to another project which is using Travis CI. It struck me that it would be really cool if Eppy had continuous integration testing for multiple Python versions, and potentially for cross-platform (OSX, Linux, Windows). Also, it seems like every programming job advertised asks for experience with CI so I thought it was worth my while to give it a try from the set-up end as well as the committing end.

This pull request adds a `.travis.yml` and adds the Travis CI build files to the main `.gitignore`. It also adds the latest version of `numpy` to `requirements.txt` as that was causing the build to fail.

It was incredibly quick and easy to set up by linking my GitHub, so should be equally quick at your end (if you haven't already done so). Here's the [quick guide](https://docs.travis-ci.com/user/getting-started/) - which is really simple.

This is a branch off the `master` branch, so if a) you think adding CI is a good idea and b) you'd rather it was branching off the `develop` branch, let me know and I'll do it again that way.