### PR TITLE
Replaced pydot with pydot3k

### DIFF
--- a/p3/setup.py
+++ b/p3/setup.py
@@ -43,7 +43,7 @@ setup(
                 "beautifulsoup4>=4.2.1",
                 # "numpy>=1.7.1",
                 "pyparsing>=pyparsing",
-                "pydot>1.0",
+                "pydot3k>1.0",
                 "pytest>=2.3.5",
                     ],
     cmdclass={'test': PyTest},


### PR DESCRIPTION
In the requirements.txt "pydot>1.0" has been replaced with "pydot3k".