### PR TITLE
Bugfix to master branch to fix issue #119 - failing installation on python 3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+# .coveragerc to control coverage.py
+[run]
+# don't report on coverage of files in the tests dir itself
+omit = 
+  eppy/tests/*
+  eppy/iddv*
+  eppy/Main_Tutorial.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,22 @@ language: python
 python:
   - "2.7"
   - "3.5"
-
-install:
+before_install:
   # Update the Python 3 code, and change to the p3 dir if required
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then cd eppy; sh 2to3sh.sh; cd ../p3; fi
-  - pip install -r requirements.txt
+
+  # coverage and testing requirements
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
   - pip install pytest-cov
   - pip install codecov
 
-script: coverage run --source=eppy  
-                     --omit=eppy/tests/test_runner.py -m py.test -v
+install:
+  - python setup.py install
+
+script:
+  # run all tests in eppy/tests and check coverage of the eppy dir
+  - py.test -v --cov-config .coveragerc --cov=eppy eppy/tests
 
 after_success:
     - codecov

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+release r0.5.3
+~~~~~~~~~~~~~~
+
+2016-08-24
+----------
+
+- bug fix -> fix python3 installation.
+
 release r0.5.2
 ~~~~~~~~~~~~~~
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,4 +13,4 @@ Go to http://www.numpy.org and install NumPy.
 
 Go to  http://www.graphviz.org and install graphviz
 
-*Note: eppy runs on python2. There are plans for python3, but we are not there yet*
+*Note: eppy runs on python2 and python 3.*

--- a/eppy/EPlusInterfaceFunctions/mylib2.py
+++ b/eppy/EPlusInterfaceFunctions/mylib2.py
@@ -13,7 +13,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os, pickle, cPickle
+import os, pickle
 # import string
 import eppy.EPlusInterfaceFunctions.mylib1 as mylib1
 
@@ -319,13 +319,3 @@ def pickledump(theobject, fname):
     """same as pickle.dump(theobject, fhandle).takes filename as parameter"""
     fhandle = open(fname, 'wb')
     pickle.dump(theobject, fhandle)
-
-def cpickleload(fname):
-    """same as pickle.load(fhandle).takes filename as parameter"""
-    fhandle = open(fname, 'rb')
-    return cPickle.load(fhandle)
-
-def cpickledump(theobject, fname):
-    """same as pickle.dump(theobject, fhandle).takes filename as parameter"""
-    fhandle = open(fname, 'wb')
-    cPickle.dump(theobject, fhandle)

--- a/eppy/__init__.py
+++ b/eppy/__init__.py
@@ -1,2 +1,2 @@
 """version number"""
-__version__ = '0.5.2'
+__version__ = '0.5.3'

--- a/p3/README.txt
+++ b/p3/README.txt
@@ -1,0 +1,31 @@
+Eppy
+====
+
+Eppy is a scripting language for EnergyPlus idf files, and EnergyPlus output files. Eppy is written in the programming language Python. As a result it takes full advantage of the rich data structure and idioms that are avaliable in python. You can programmatically navigate, search, and modify EnergyPlus idf files using eppy. The power of using a scripting language allows you to do the following:
+
+- Make a large number of changes in an idf file with a few lines of eppy code.
+- Use conditions and filters when making changes to an idf file
+- Make changes to multiple idf files.
+- Read data from the output files of a EnergyPlus simulation run.
+- Based on the results of a EnergyPlus simulation run, generate the input file for the next simulation run.
+
+So what does this matter? 
+Here are some of the things you can do with eppy:
+
+
+- Change construction for all north facing walls.
+- Change the glass type for all windows larger than 2 square meters.
+- Change the number of people in all the interior zones.
+- Change the lighting power in all south facing zones.
+- Change the efficiency and fan power of all rooftop units.
+- Find the energy use of all the models in a folder (or of models that were run after a certain date)
+
+You can install from :
+<https://pypi.python.org/pypi/eppy/>
+
+The documentation is at:
+<http://pythonhosted.org//eppy/>
+
+to get a quick sense of how it feels to use eppy, take a look at
+<http://pythonhosted.org//eppy/Main_Tutorial.html>
+

--- a/p3/eppy/__init__.py
+++ b/p3/eppy/__init__.py
@@ -1,2 +1,2 @@
 """version number"""
-__version__ = '0.5'
+__version__ = '0.5.3'


### PR DESCRIPTION
This both fixes #119 by removing the dependency on `cPickle`, and ensures that similar issues will be caught by the CI in future, by installing more like it would be from `pip` rather than using `requirements.txt`.

@santoshphilip I've done what I could think of towards preparing the repo for a bugfix release but I'm sure there are things I've missed and assume you have a checklist/process to follow. By the way, it would be great to automate releases to save you time - so that as long as an update to the `master` branch passes all the tests (unit tests, integration tests, and coverage level) then it gets uploaded to PyPI with whatever major/minor/bugfix version bump is specified. There are a few packages out there to do this smoothly.