### PR TITLE
Improve pytest integration and setup.py for CI platforms

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,5 @@ omit =
   eppy/tests/*
   eppy/iddv*
   eppy/Main_Tutorial.py
+  venv/*
+  

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,14 @@
 .ipynb_checkpoints/
 .cache
 __pycache__
+
 # Eclipse/PyDev
 .project
 .pydevproject
 .settings/
 /remove_licence.py
 /.coverage
+
+# Builds
+.eggs
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,13 @@ before_install:
   - source venv/bin/activate
 
   # coverage and testing requirements
+  - pip install --upgrade setuptools
   - pip install --upgrade pip
   - pip install pytest-cov
   - pip install codecov
 
-install:
-  - python setup.py install
-
-script: py.test ./eppy/tests --cov=./ -v
+script:
+  - python setup.py test
 
 after_success:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then codecov; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,18 +27,19 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.
+  # Upgrade to the latest version of pip and setuptools to avoid displaying
+  # warnings about it being out of date.
   - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "pip install --upgrade setuptools"
+  
   - ps: echo $env:PYTHON
-  - "%PYTHON%\\python.exe -m pip install pytest"
+  - "pip install pytest"
+  - "pip install pytest-cov"
   # set the integration test environment variable
   - "SET EPPY_INTEGRATION=TRUE"
-  # install rppy
-  - "%PYTHON%\\python.exe setup.py install"
 
 build: off
 
 test_script:
   # Test command.
-  - "%PYTHON%\\python.exe -m pytest eppy -v"
+  - "%PYTHON%\\python.exe setup.py test"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,12 @@
 omit = 
     eppy/iddv*.py
     venv/*
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts =
+    eppy/tests
+    --verbose 
+    --cov=./

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 omit = 
     eppy/iddv*.py
     venv/*
+    setup.py
 
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,28 @@
 
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-import io
-import codecs
 import os
-import sys
 
 import eppy
+from setuptools import setup
 
-here = os.path.abspath(os.path.dirname(__file__))
 
-def read(*filenames, **kwargs):
-    encoding = kwargs.get('encoding', 'utf-8')
-    sep = kwargs.get('sep', '\n')
-    buf = []
-    for filename in filenames:
-        with io.open(filename, encoding=encoding) as f:
-            buf.append(f.read())
-    return sep.join(buf)
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-long_description = read('README.txt')
 
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errcode = pytest.main(self.test_args)
-        sys.exit(errcode)
+def read_md(f):
+    try:
+        from pypandoc import convert
+        try:
+            return convert(os.path.join(THIS_DIR, f), 'rst')
+        except:
+            return "Eppy"
+    except ImportError:
+        print("warning: pypandoc module not found, could not convert Markdown to RST")
+        try:
+            with open(os.path.join(THIS_DIR, f), 'r') as f_in:
+                return f_in.read()
+        except:
+            return "Eppy"
+    
 
 setup(
     name='eppy',
@@ -38,19 +30,15 @@ setup(
     url='https://github.com/santoshphilip/eppy',
     license='MIT License',
     author='Santosh Philip',
-    tests_require=['pytest'],
-    cmdclass={'test': PyTest},
     author_email='eppy_scripting@yahoo.com',
     description='Scripting language for E+ idf files, and E+ output files',
-    long_description=long_description,# TODO set this up
+    long_description=read_md('README.md'),
     packages=['eppy', 'eppy.EPlusInterfaceFunctions', 'eppy.geometry', 'eppy.constructions'],
     include_package_data=True,
     platforms='any',
-    test_suite='eppy.test.test_eppy',# TODO make test_eppy
     install_requires = [
         "munch>=2.0.2",
         "beautifulsoup4>=4.2.1",
-        "pytest>=2.3.5",
         "tinynumpy>=1.2.1",
         "six>=1.10.0",
         "decorator>=4.0.10"
@@ -67,13 +55,14 @@ setup(
         'Topic :: Scientific/Engineering',
         ],
     extras_require={
-        'python_version<="2.7"': [
+        ':python_version<="2.7"': [
             'pydot>1.0',
-            'pyparsing==1.5.7'
+            'pyparsing>=2.1.4'
             ],
-        'python_version>="3.5"': [
+        ':python_version>="3.5"': [
             'pydot3k',
             ],
-        'testing': ['pytest'],        
-    }
+        },
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
 )


### PR DESCRIPTION
`setup.py` changes
Remove pytest from install_requires and put into tests_require.
Remove unused sections of setup.py.
Create the long description directly from README.md (this requires `pypandoc` to be installed in the environment used to build release versions).

`CI changes`
Call pytest using `python setup.py test` on CI platforms.
Upgrade setuptools to avoid failing CI on OSX.
Fix coverage reporting on Appveyor.
Omit venv from test coverage report.

Resolves: #123 
