### PR TITLE
Catch idd_index returned by readdatacommdct

### DIFF
--- a/eppy/tests/test_loopdiagram.py
+++ b/eppy/tests/test_loopdiagram.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import subprocess
 
 from eppy.pytest_helpers import do_integration_tests
 import pytest
@@ -113,4 +114,3 @@ def test_getedges():
     idd = os.path.join(IDD_FILES, "Energy+V8_1_0.idd")
     fname = os.path.join(IDF_FILES, "V8_1_0/Boiler.idf")
     getedges(fname, idd)
-    

--- a/eppy/tests/test_loopdiagram.py
+++ b/eppy/tests/test_loopdiagram.py
@@ -14,14 +14,15 @@ from __future__ import unicode_literals
 
 import os
 
+from eppy.pytest_helpers import do_integration_tests
 import pytest
 
 from eppy.useful_scripts.loopdiagram import clean_edges
 from eppy.useful_scripts.loopdiagram import dropnodes
 from eppy.useful_scripts.loopdiagram import edges2nodes
+from eppy.useful_scripts.loopdiagram import getedges
 from eppy.useful_scripts.loopdiagram import process_idf
 from eppy.useful_scripts.loopdiagram import replace_colon
-from eppy.pytest_helpers import do_integration_tests
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -104,3 +105,12 @@ def test_loopdiagram_integration():
     idd = os.path.join(IDD_FILES, "Energy+V8_1_0.idd")
     fname = os.path.join(IDF_FILES, "V8_1_0/Boiler.idf")
     process_idf(fname, idd)
+
+
+@pytest.mark.skipif(
+    not do_integration_tests(), reason="$EPPY_INTEGRATION env var not set")
+def test_getedges():
+    idd = os.path.join(IDD_FILES, "Energy+V8_1_0.idd")
+    fname = os.path.join(IDF_FILES, "V8_1_0/Boiler.idf")
+    getedges(fname, idd)
+    

--- a/eppy/tests/test_loopdiagram.py
+++ b/eppy/tests/test_loopdiagram.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import subprocess
 
 from eppy.pytest_helpers import do_integration_tests
 import pytest

--- a/eppy/useful_scripts/loopdiagram.py
+++ b/eppy/useful_scripts/loopdiagram.py
@@ -545,6 +545,9 @@ def main():
     parser.add_argument('idd', nargs='?', type=str, action='store', 
         help='location of idd file = ./somewhere/eplusv8-0-1.idd')
     args = parser.parse_args()
+    if not (args.file and args.idd):
+        parser.print_help()
+        sys.exit(1)
     make_and_save_diagram(args.file, args.idd)
 
 

--- a/eppy/useful_scripts/loopdiagram.py
+++ b/eppy/useful_scripts/loopdiagram.py
@@ -540,12 +540,10 @@ def main():
                 description=__doc__, 
                 formatter_class=argparse.RawTextHelpFormatter)
                 # need the formatter to print newline from __doc__
-    parser.add_argument('idd', type=str, action='store', 
-        help='location of idd file = ./somewhere/eplusv8-0-1.idd',
-        required=True)
-    parser.add_argument('file', type=str, action='store', 
-        help='location of idf file = ./somewhere/f1.idf',
-        required=True)
+    parser.add_argument('file', nargs='?', type=str, action='store', 
+        help='location of idf file = ./somewhere/f1.idf')
+    parser.add_argument('idd', nargs='?', type=str, action='store', 
+        help='location of idd file = ./somewhere/eplusv8-0-1.idd')
     args = parser.parse_args()
     make_and_save_diagram(args.file, args.idd)
 

--- a/eppy/useful_scripts/loopdiagram.py
+++ b/eppy/useful_scripts/loopdiagram.py
@@ -491,7 +491,7 @@ def makeairplantloop(data, commdct):
 
 def getedges(fname, iddfile):
     """return the edges of the idf file fname"""
-    data, commdct = readidf.readdatacommdct(fname, iddfile=iddfile)
+    data, commdct, idd_index = readidf.readdatacommdct(fname, iddfile=iddfile)
     edges = makeairplantloop(data, commdct)
     return edges
 


### PR DESCRIPTION
This was missed when fixing #128 since we didn't have a test for `loopdiagram.getedges`.
This is fixed and is now included in an integration test.

Resolves: #130 
