### PR TITLE
Fix CI issue on OSX with Python 2.7 in weppy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
   # install python
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ $PYTHON == 2* ]]; then brew install python; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ $PYTHON == 2* ]]; then brew install python; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ $PYTHON == 3* ]]; then brew install python3; fi
   # activate virtual env
   - if [[ $PYTHON == 2* ]]; then virtualenv venv -p python; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_install:
 
   # install python
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ $PYTHON == 2* ]]; then brew install python; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ $PYTHON == 3* ]]; then brew install python3; fi
   # activate virtual env
   - if [[ $PYTHON == 2* ]]; then virtualenv venv -p python; fi


### PR DESCRIPTION
Travis CI now has Python 2.7 installed by default on OSX so we don't need to install it ourselves.