### PR TITLE
Rewrite the the "no warning" test to avoid the new pytest behaviour

### DIFF
--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -740,7 +740,7 @@ class IDF(object):
         obj = newrawobject(self.model, self.idd_info, key)
         abunch = obj2bunch(self.model, self.idd_info, obj)
         if aname:
-            warnings.warn("The aname parameter should no longer be used.")
+            warnings.warn("The aname parameter should no longer be used.", UserWarning)
             namebunch(abunch, aname)
         self.idfobjects[key].append(abunch)
         for k, v in list(kwargs.items()):

--- a/eppy/tests/test_modeleditor.py
+++ b/eppy/tests/test_modeleditor.py
@@ -343,29 +343,27 @@ def test_newidfobject():
     assert obj.fieldvalues[1] == 'A Wall'
 
 
-# def test_newidfobject_warning():
-#     """Test that the warning for newidfobject created with `aname` is working.
-#
-#     Fails if the warning is not issued when `aname` is used, or if the warning
-#     is issued when `aname` is not used.
-#     """
-#     # make a blank idf
-#     # make a function for this and then continue.
-#     idf = IDF()
-#     idf.new()
-#     objtype = 'material:airgap'.upper()
-#     # expect warnings here
-#     pytest.warns(UserWarning, idf.newidfobject, objtype, aname="Krypton")
-#     pytest.warns(UserWarning, idf.newidfobject, objtype, "Krypton")
-#     # expect no warnings here
-#     # This works because pytest.warn raises an exception if no warning is
-#     # produced. We expect this and catch it with pytest.raises.
-#     pytest.raises(
-#         Exception,
-#         pytest.warns, UserWarning,
-#         idf.newidfobject,
-#         objtype, Name="Krypton")
+def test_newidfobject_warning():
+    """Test that the warning for newidfobject created with `aname` is working.
 
+    Fails if the warning is not issued when `aname` is used, or if the warning
+    is issued when `aname` is not used.
+    """
+    # make a blank idf
+    # make a function for this and then continue.
+    idf = IDF()
+    idf.new()
+    objtype = 'material:airgap'.upper()
+    # expect warnings here
+    with pytest.warns(UserWarning):
+        idf.newidfobject(objtype, aname="Krypton")
+    with pytest.warns(UserWarning):
+        idf.newidfobject(objtype, "Krypton")
+
+    # expect no warnings here - we pass None so as not to trigger the `Failed: DID NOT WARN` message from pytest
+    with pytest.warns(None) as captured_warnings:
+        idf.newidfobject(objtype, Name="Krypton")
+    assert len(captured_warnings) == 0
 
 def test_save():
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4>=4.2.1
 pydot>1.0; python_version <= '2.7'
 pydot3k; python_version >= '3.0'
 pyparsing==1.5.7; python_version <= '2.7'
-pytest>=2.3.5
+pytest>=3.2.1
 tinynumpy>=1.2.1
 six>=1.10.0
 decorator>=4.0.10


### PR DESCRIPTION
This error was caused by pytest raising an error when seeing that no
warning was raised during a test using `pytest.warn`. For some reason
this wasn't being caught by `pytest.raises`. In any case, the test
wasn't very readable so we have rewritten it to make it clearer how it
work.

Fixes #163