### PR TITLE
Get the EnergyPlus install path from the IDD if possible

### DIFF
--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -1001,7 +1001,7 @@ class IDF(object):
         # write the IDF to the current directory
         self.saveas('in.idf')
         # run EnergyPlus
-        run(self, self.epw, **kwargs)
+        run(self, self.epw, iddname=self.iddname, **kwargs)
         # remove in.idf
         os.remove('in.idf')
 

--- a/eppy/tests/test_runner.py
+++ b/eppy/tests/test_runner.py
@@ -54,7 +54,7 @@ TEST_EPW = 'USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw'
 TEST_IDD = "Energy+V{}.idd".format(VERSION.replace('-', '_'))
 TEST_OLD_IDD = 'Energy+V8_1_0.idd'
 
-eplus_exe, eplus_weather = install_paths(VERSION)
+eplus_exe, eplus_weather = install_paths(VERSION, os.path.join(IDD_FILES, TEST_IDD))
 
 
 def has_severe_errors(results='run_outputs'):


### PR DESCRIPTION
Addresses issue #175 

This is designed to be backwards-compatible by adding a new kwarg to the `install_paths` function.