### PR TITLE
Use the existing `idd` parameter instead of adding `iddname`

### DIFF
--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -1002,8 +1002,9 @@ class IDF(object):
         self.saveas('in.idf')
         # if `idd` is not passed explicitly, use the IDF.iddname
         idd = kwargs.pop('idd', self.iddname)
+        epw = kwargs.pop('weather', self.epw)
         # run EnergyPlus
-        run(self, self.epw, idd=idd, **kwargs)
+        run(self, weather=epw, idd=idd, **kwargs)
         # remove in.idf
         os.remove('in.idf')
 

--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -1000,8 +1000,10 @@ class IDF(object):
         """
         # write the IDF to the current directory
         self.saveas('in.idf')
+        # if `idd` is not passed explicitly, use the IDF.iddname
+        idd = kwargs.pop('idd', self.iddname)
         # run EnergyPlus
-        run(self, self.epw, iddname=self.iddname, **kwargs)
+        run(self, self.epw, idd=idd, **kwargs)
         # remove in.idf
         os.remove('in.idf')
 

--- a/eppy/runner/run_functions.py
+++ b/eppy/runner/run_functions.py
@@ -194,7 +194,7 @@ def multirunner(args):
 def run(idf=None, weather=None, output_directory='', annual=False,
         design_day=False, idd=None, epmacro=False, expandobjects=False,
         readvars=False, output_prefix=None, output_suffix=None, version=False,
-        verbose='v', ep_version=None, iddname=None):
+        verbose='v', ep_version=None):
     """
     Wrapper around the EnergyPlus command line interface.
 
@@ -266,7 +266,7 @@ def run(idf=None, weather=None, output_directory='', annual=False,
     # get unneeded params out of args ready to pass the rest to energyplus.exe
     verbose = args.pop('verbose')
     idf = args.pop('idf')
-    iddname = args.pop('iddname')
+    iddname = args.get('idd')
     try:
         idf_path = os.path.abspath(idf.idfname)
     except AttributeError:


### PR DESCRIPTION
See issue #183 

Also fixes a bug where `self.epw` is not set. Even if the `weather` keyword arg is used, the current version will fail as it tries to find `self.epw` first.

The correct behaviour is to try to use the  `weather` kwarg if it is specified, otherwise use `self.epw`, and only at that point raise an exception  if `self.epw` has not been set.