### PR TITLE
Docs and test to show that generators can be passed to runIDFs

### DIFF
--- a/eppy/runner/run_functions.py
+++ b/eppy/runner/run_functions.py
@@ -138,14 +138,14 @@ def wrapped_help_text(wrapped_func):
     return decorator
 
 
-def runIDFs(jobs_list, processors=1):
+def runIDFs(jobs, processors=1):
     """Wrapper for run() to be used when running IDF5 runs in parallel.
 
     Parameters
     ----------
-    jobs_list : list
-        A list made up of an IDF5 object and a kwargs dict (see .
-
+    jobs : iterable
+        A list or generator made up of an IDF5 object and a kwargs dict
+        (see `run_functions.run` for valid keywords).
     processors : int, optional
         Number of processors to run on (default: 1). If 0 is passed then
         the process will run on all CPUs, -1 means one less than all CPUs, etc.
@@ -157,26 +157,32 @@ def runIDFs(jobs_list, processors=1):
     shutil.rmtree("multi_runs", ignore_errors=True)
     os.mkdir("multi_runs")
 
-    processed_runs = []
-    for i, item in enumerate(jobs_list):
-        idf = item[0]
-        epw = idf.epw
-        kwargs = item[1]
-        idf_dir = os.path.join('multi_runs', 'idf_%i' % i)
-        os.mkdir(idf_dir)
-        idf_path = os.path.join(idf_dir, 'in.idf')
-        idf.saveas(idf_path)
-        processed_runs.append([[idf_path, epw], kwargs])
-
+    prepared_runs = (prepare_run(run_id, run_data) for run_id, run_data in enumerate(jobs))
     try:
         pool = mp.Pool(processors)
-        pool.map(multirunner, processed_runs)
+        pool.map(multirunner, prepared_runs)
         pool.close()
     except NameError:
         # multiprocessing not present so pass the jobs one at a time
-        for job in processed_runs:
+        for job in prepared_runs:
             multirunner([job])
     shutil.rmtree("multi_runs", ignore_errors=True)
+
+
+def prepare_run(run_id, run_data):
+    """Prepare run inputs for one of multiple EnergyPlus runs.
+
+    :param run_id: An ID number for naming the IDF.
+    :param run_data: Tuple of the IDF and keyword args to pass to EnergyPlus executable.
+    :return: Tuple of the IDF path and EPW, and the keyword args.
+    """
+    idf, kwargs = run_data
+    epw = idf.epw
+    idf_dir = os.path.join('multi_runs', 'idf_%i' % run_id)
+    os.mkdir(idf_dir)
+    idf_path = os.path.join(idf_dir, 'in.idf')
+    idf.saveas(idf_path)
+    return (idf_path, epw), kwargs
 
 
 def multirunner(args):

--- a/eppy/tests/test_runner.py
+++ b/eppy/tests/test_runner.py
@@ -572,3 +572,28 @@ class TestMultiprocessing(object):
 
         num_CPUs = -1
         runIDFs(runs, num_CPUs)
+
+    def test_multiprocess_run_IDF_from_generator(self):
+        """
+        Test that we can run a sequence passed as a generator of runs using
+        the signature:
+            runIDFs(([IDF, kwargs],...), num_CPUs)
+        Fails if expected output files are not in the expected output
+        directories.
+
+        """
+        iddfile = os.path.join(IDD_FILES, TEST_IDD)
+        fname1 = os.path.join(IDF_FILES, TEST_IDF)
+        modeleditor.IDF.setiddname(open(iddfile, 'r'), testing=True)
+        ep_version = '-'.join(str(x) for x in modeleditor.IDF.idd_version[:3])
+        assert ep_version == VERSION
+        runs = (
+            (modeleditor.IDF(open(fname1, 'r'), TEST_EPW),
+             {'output_directory': 'results_%i' % i, 'ep_version': ep_version})
+            for i in range(4)
+        )
+        num_CPUs = 2
+        runIDFs(runs, num_CPUs)
+
+        num_CPUs = -1
+        runIDFs(runs, num_CPUs)


### PR DESCRIPTION
If a very large list is passed in then a huge amount of memory can be used (#210). Passing a generator allows the IDFs to be created only when needed.

This was always possible as input to `runIDFs`, but we now also use a generator internally for a small improvement when preparing the runs to pass to the `multiprocessing` pool. We also add a test for this behaviour, and document that any iterable can be passed in, rather than specifying a list.