### PR TITLE
Fixes the TypeError

### DIFF
--- a/eppy/bunch_subclass.py
+++ b/eppy/bunch_subclass.py
@@ -384,7 +384,7 @@ class EpBunch(Bunch):
 
     def __dir__(self):
         fnames = self.fieldnames
-        func_names = self['__functions'].keys()
+        func_names = list(self['__functions'].keys())
         return super(EpBunch, self).__dir__() + fnames + func_names
 
 


### PR DESCRIPTION
References issue #113
- `TypeError: can only concatenate list (not "dict_keys") to list`is fixed

Creating this pull request to let Travis and AppVeyor do their thing...