### PR TITLE
i242 case insensitive dict

### DIFF
--- a/eppy/EPlusInterfaceFunctions/structures.py
+++ b/eppy/EPlusInterfaceFunctions/structures.py
@@ -1,0 +1,45 @@
+"""Implements a case-insensitive dict, based on https://stackoverflow.com/a/32888599/1706564"""
+from six import string_types
+
+
+class CaseInsensitiveDict(dict):
+    @classmethod
+    def _k(cls, key):
+        return key.upper() if isinstance(key, string_types) else key
+
+    def __init__(self, *args, **kwargs):
+        super(CaseInsensitiveDict, self).__init__(*args, **kwargs)
+        self._convert_keys()
+
+    def __getitem__(self, key):
+        return super(CaseInsensitiveDict, self).__getitem__(self.__class__._k(key))
+
+    def __setitem__(self, key, value):
+        super(CaseInsensitiveDict, self).__setitem__(self.__class__._k(key), value)
+
+    def __delitem__(self, key):
+        return super(CaseInsensitiveDict, self).__delitem__(self.__class__._k(key))
+
+    def __contains__(self, key):
+        return super(CaseInsensitiveDict, self).__contains__(self.__class__._k(key))
+
+    def has_key(self, key):
+        return super(CaseInsensitiveDict, self).has_key(self.__class__._k(key))
+
+    def pop(self, key, *args, **kwargs):
+        return super(CaseInsensitiveDict, self).pop(self.__class__._k(key), *args, **kwargs)
+
+    def get(self, key, *args, **kwargs):
+        return super(CaseInsensitiveDict, self).get(self.__class__._k(key), *args, **kwargs)
+
+    def setdefault(self, key, *args, **kwargs):
+        return super(CaseInsensitiveDict, self).setdefault(self.__class__._k(key), *args, **kwargs)
+
+    def update(self, E=None, **F):
+        super(CaseInsensitiveDict, self).update(self.__class__(E))
+        super(CaseInsensitiveDict, self).update(self.__class__(**F))
+
+    def _convert_keys(self):
+        for k in list(self.keys()):
+            v = super(CaseInsensitiveDict, self).pop(k)
+            self.__setitem__(k, v)

--- a/eppy/idfreader.py
+++ b/eppy/idfreader.py
@@ -15,6 +15,7 @@ from itertools import chain
 
 from eppy.EPlusInterfaceFunctions import readidf
 import eppy.bunchhelpers as bunchhelpers
+from eppy.EPlusInterfaceFunctions.structures import CaseInsensitiveDict
 from eppy.bunch_subclass import EpBunch
 # from eppy.bunch_subclass import fieldnames, fieldvalues
 import eppy.iddgaps as iddgaps
@@ -71,7 +72,7 @@ def makeabunch(commdct, obj, obj_i, debugidd=True, block=None):
 
 def makebunches(data, commdct):
     """make bunches with data"""
-    bunchdt = {}
+    bunchdt = CaseInsensitiveDict()
     ddtt, dtls = data.dt, data.dtls
     for obj_i, key in enumerate(dtls):
         key = key.upper()
@@ -85,7 +86,7 @@ def makebunches(data, commdct):
 
 def makebunches_alter(data, commdct, theidf, block=None):
     """make bunches with data"""
-    bunchdt = {}
+    bunchdt = CaseInsensitiveDict()
     dt, dtls = data.dt, data.dtls
     for obj_i, key in enumerate(dtls):
         key = key.upper()

--- a/eppy/tests/conftest.py
+++ b/eppy/tests/conftest.py
@@ -35,6 +35,7 @@ def test_idf():
         assert ep_version == versiontuple(VERSION)
     except AttributeError:
         raise
+    return idf
 
 
 @pytest.fixture()

--- a/eppy/tests/conftest.py
+++ b/eppy/tests/conftest.py
@@ -1,7 +1,10 @@
 import os
 
 import pytest
+from six import StringIO
 
+from eppy.modeleditor import IDF
+from eppy.iddcurrent import iddcurrent
 from eppy import modeleditor
 from eppy.tests.test_runner import versiontuple
 
@@ -32,4 +35,14 @@ def test_idf():
         assert ep_version == versiontuple(VERSION)
     except AttributeError:
         raise
+
+@pytest.fixture()
+def base_idf():
+    iddsnippet = iddcurrent.iddtxt
+    iddfhandle = StringIO(iddsnippet)
+    if IDF.getiddname() == None:
+        IDF.setiddname(iddfhandle)
+    idftxt = ""
+    idfhandle = StringIO(idftxt)
+    idf = IDF(idfhandle)
     return idf

--- a/eppy/tests/test_case_insensitive.py
+++ b/eppy/tests/test_case_insensitive.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.parametrize("key", ["BUILDING", "Building", "building", "BuIlDiNg"])
+def test_get_and_set(base_idf, key):
+    idf = base_idf
+    idf.newidfobject(key, Name="Building")
+    buildings = idf.idfobjects["building"]
+    assert len(buildings) == 1
+
+
+@pytest.mark.parametrize("key", ["BUILDING", "Building", "building", "BuIlDiNg"])
+def test_contains(base_idf, key):
+    idf = base_idf
+    idf.newidfobject(key, Name="Building")
+    assert key in idf.idfobjects
+
+
+@pytest.mark.parametrize("key", ["BUILDING", "Building", "building", "BuIlDiNg"])
+def test_del(base_idf, key):
+    idf = base_idf
+    idf.newidfobject(key, Name="Building")
+    assert key in idf.idfobjects
+    del idf.idfobjects["building"]
+    assert key not in idf.idfobjects


### PR DESCRIPTION
This uses the community wiki implementation of a case-insensitive python dict from https://stackoverflow.com/a/32888599/1706564 - the only changes are:

 1. avoid passing a mutable argument to the `update` method
 2. to normalize keys to upper-case rather than lower
 3. use `string_type` from`six` instead of `basestring` for 2/3 compatibility

It tests the typical use case (getting and setting) as well as the `__contains__` magic method used by the `in` operator, and `__delitem__` used by the `del` operator.

Addresses #242 