### PR TITLE
I248 catch install failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,18 +82,18 @@ before_install:
     fi
   - python --version;
 
-  # coverage and testing requirements
+install:
   - pip install --upgrade setuptools
   - pip install --upgrade pip
-  - pip install pytest-cov
-  - pip install codecov
-
-install:
   - python setup.py install
   # install numpy and remove tinynumpy if testing with numpy
   - if [[ $NUMPY == numpy ]]; then pip install numpy; pip uninstall tinynumpy -y; fi
+  # we wait to install test dependencies after installing eppy, so as to catch any missing dependencies during setup.py
+  - pip install pytest-cov==2.7.1
+  - pip install codecov
 
-script: py.test ./eppy/tests --cov=./ -v
+script:
+  - py.test ./eppy/tests --cov=./ -v
 
 after_success:
   # coverage reporting on CodeCov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,6 +69,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda info -a
   - conda update -q conda
+  - activate
   - "conda create -n test-env python=%PYTHONVERSION% pytest lxml"
   - "activate test-env"
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     install_requires = [
         "munch>=2.0.2",
         "beautifulsoup4>=4.2.1",
-        "pytest>=3.2.1",
         "tinynumpy>=1.2.1",
         "six>=1.10.0",
         "decorator>=4.0.10",


### PR DESCRIPTION
@santoshphilip very nice investigation in #248, thanks. Solution is, as you suggest, to install the test dependencies after the main `setup.py` has run.

There was also a conflict with conda in the appveyor file, so I've fixed that here too, and removed pytest from the main dependencies in `setup.py`, since it's already listed in the test dependencies.