### PR TITLE
New: Return default value of fieldvalue when possible

### DIFF
--- a/eppy/bunch_subclass.py
+++ b/eppy/bunch_subclass.py
@@ -321,7 +321,13 @@ class EpBunch(Bunch):
             try:
                 return self.fieldvalues[i]
             except IndexError:
-                return ""
+                # try to return the default value if defined in IDD.
+                if 'default' in self.getfieldidd(name).keys():
+                    _type = _parse_idd_type(self, name)
+                    default_ = next(iter(self.getfieldidd(name)['default']), None)
+                    return _type(default_)
+                else:
+                    return ""
         else:
             astr = "unable to find field %s" % (name,)
             raise BadEPFieldError(astr)
@@ -392,6 +398,18 @@ class EpBunch(Bunch):
         fnames = self.fieldnames
         func_names = list(self["__functions"].keys())
         return super(EpBunch, self).__dir__() + fnames + func_names
+
+
+def _parse_idd_type(epbunch, name):
+    """parse the fieldvalue type into a python type. eg.: 'real' returns
+    'float'"""
+    _type = next(iter(epbunch.getfieldidd(name)['type']), None)
+    if _type == 'real':
+        return float
+    elif _type == 'alpha':
+        return str
+    else:
+        return str
 
 
 def getrange(bch, fieldname):


### PR DESCRIPTION
@santoshphilip, @jamiebull1 
Hi guys, completely unrelated to the decorators pull request; I encountered a situation where I needed the default value of a fieldvalue when it is not specified in the IDF file. For example, an OpaqueMaterial that does not have the Solar_Absorptance value defined will return "" instead if the default value set in the IDD for that field (0.7).

I simply added a condition in __getattr__ to check if 'default' is in the fieldidd, and if so to return the value. Since the type of the value is also provided ('real', 'alpha', etc.), I created a simple type_parser that translates the idd-defined type to a Python type (eg.: 'real' => 'float')

The type_parser should probably include all possible types in an IDF file. Don't know how to get the complete list of possibilities. Ideas?