### PR TITLE
I254 set expandobjects

### DIFF
--- a/eppy/runner/run_functions.py
+++ b/eppy/runner/run_functions.py
@@ -297,6 +297,13 @@ def run(
         idf_path = os.path.abspath(idf.idfname)
     except AttributeError:
         idf_path = os.path.abspath(idf)
+    if not os.path.isfile(idf_path):
+        raise EnergyPlusRunError(
+            "ERROR: Could not find input data file: {}".format(idf_path)
+        )
+    if not expandobjects:
+        with open(idf_path, "r") as f:
+            args["expandobjects"] = "HVACTEMPLATE:" in f.read().upper()
     ep_version = args.pop("ep_version")
     # get version from IDF object or by parsing the IDF file for it
     if not ep_version:

--- a/eppy/tests/test_runner.py
+++ b/eppy/tests/test_runner.py
@@ -368,6 +368,26 @@ class TestIDFRunner(object):
         self.expected_files.extend(["eplusout.expidf"])
         assert set(files) == set(self.expected_files)
 
+    def test_run_expandobjects_no_flag(self, test_idf):
+        """
+        End to end test of idf.run function with expandobjects flag unset.
+        Fails on severe errors or unexpected/missing output files.
+
+        """
+        test_idf.newidfobject(
+            "HVACTEMPLATE:THERMOSTAT",
+            Name="TestThermostat",
+            Cooling_Setpoint_Schedule_Name="",
+            Heating_Setpoint_Schedule_Name="",
+            Constant_Cooling_Setpoint=25,
+            Constant_Heating_Setpoint=21,
+        )
+        test_idf.run(output_directory="run_outputs")
+        assert not has_severe_errors()
+        files = os.listdir("run_outputs")
+        self.expected_files.extend(["eplusout.expidf"])
+        assert set(files) == set(self.expected_files)
+
     def test_run_output_prefix(self, test_idf):
         """
         End to end test of idf.run function with output prefix set.


### PR DESCRIPTION
Often users have HVACTemplate objects in their IDF, but don't set the `expandobjects` flag when using `IDF.run`, leading to an `EnergyPlusRunError`.

I think we should just fix it automatically, by checking if there are  any HVACTemplate objects, and setting the flag to `True` if needed.

The only negative impact I see is that there is a cost to reading the IDF, which may add up on multiprocessing jobs, but it's miniscule compared to the actual EnergyPlus running time.