### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyparsing
 pytest
 tinynumpy
 six
-decorator
+decorator==4.4.2
 lxml
 future
 


### PR DESCRIPTION
Fix issue [#332](https://github.com/santoshphilip/eppy/issues/332) by specifying the required decorator module version. 

The newer versions of decorator package will cause errors in parsing .idd file.