### PR TITLE
run: make idd path absolute, as we change cwd before running EP

### DIFF
--- a/eppy/runner/run_functions.py
+++ b/eppy/runner/run_functions.py
@@ -330,6 +330,8 @@ def run(
         args["weather"] = os.path.join(eplus_weather_path, args["weather"])
     output_dir = os.path.abspath(args["output_directory"])
     args["output_directory"] = output_dir
+    if iddname is not None:
+        args["idd"] = os.path.abspath(iddname)
 
     # store the directory we start in
     cwd = os.getcwd()


### PR DESCRIPTION
Otherwise if we start with `run(idd='EnergyPlus-9.5.0/Energy+.idd')`
we end up looking for the IDD file in \<RUN DIR\>/EnergyPlus-9.5.0/Energy+.idd
where \<RUN DIR\> is some temp directory.