### PR TITLE
Removing state pollution in `zones`

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -128,6 +128,7 @@ def test_addobject():
         "",
         "Yes",
     ]
+    del zones[-1]
 
 
 def test_functions():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_addobject` by removing state pollution in python list `zones` by calling method `del`

The test can fail in this way if state pollution in `zones` is not removed:
```
        """py.test for ex_addobject.py"""
        zones = bunchdt["zone"]  # all the zones
>       assert len(zones) == 7
E       assert 8 == 7
```