### PR TITLE
Removing state pollution in `zones`

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+import copy
 
 from eppy.idfreader import idfreader
 import eppy.snippet as snippet
@@ -47,6 +48,7 @@ def test_readwrite():
 def test_pythonic():
     """py.test for ex_pythonic.py"""
     zones = bunchdt["zone"]  # all the zones
+    zones = copy.deepcopy(zones)
     zone0 = zones[0]
     # -
     printout = "PLENUM-1"


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_pythonic` by removing state pollution in python list `zones` by executing the test code with a deepcopy of `zones`.

The test can fail in this way if state pollution in `zones` is not removed:
```
        zonenames = [zone.Name for zone in zones]
>       assert printout == zonenames
E       AssertionError: assert ['PLENUM-1', ...PACE5-1', ...] == ['PLENUM-1', '...PACE5-1', ...]
E         At index 2 diff: 'SPACE2-1' != 'FIRST-SMALL-ZONE'
E         Full diff:
E         ['PLENUM-1',
E         'SPACE1-1',
E         -  'SPACE2-1',
E         +  'FIRST-SMALL-ZONE',
E         'SPACE3-1',...
