### PR TITLE
Add function to remove all IDF object of a certain type

### DIFF
--- a/eppy/modeleditor.py
+++ b/eppy/modeleditor.py
@@ -808,6 +808,18 @@ class IDF(object):
         key = idfobject.key.upper()
         self.idfobjects[key].remove(idfobject)
 
+    def removeallidfobjects(self, idfobject):
+        """Remove all IDF object of a certain type from the IDF.
+
+        Parameters
+        ----------
+        idfobject : EpBunch object
+            The IDF object to remove.
+
+        """
+        while len(self.idfobjects[idfobject]) > 0:
+            self.popidfobject(idfobject, 0)
+
     def copyidfobject(self, idfobject):
         """Add an IDF object to the IDF.
 

--- a/tests/test_modeleditor.py
+++ b/tests/test_modeleditor.py
@@ -322,6 +322,9 @@ def test_newidfobject():
         ["MATERIAL:AIRGAP", "Argon"],
         ["MATERIAL:AIRGAP", "Argon"],
     ]
+    # remove all objects
+    idf.removeallidfobjects(objtype)
+    assert len(idf.idfobjects[objtype]) == 0
     # test some functions
     objtype = "FENESTRATIONSURFACE:DETAILED"
     obj = idf.newidfobject(objtype, Name="A Wall")


### PR DESCRIPTION
I find myself often writing a loop to delete all IDF objects of a certain type when using eppy. I thought this could perhaps be a function in eppy. This PR includes a new function called `removeallidfobjects()` that does that. It also includes a test for it (passed locally).