### PR TITLE
Removing state pollution in `idd_commlst`

### DIFF
--- a/tests/EPlusInterfaceFunctions_tests/test_iddgroups.py
+++ b/tests/EPlusInterfaceFunctions_tests/test_iddgroups.py
@@ -10,6 +10,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
 from io import StringIO
 import eppy.EPlusInterfaceFunctions.iddgroups as iddgroups
 
@@ -272,7 +273,7 @@ def test_group2commlst():
     )
     for (groupcommlst,) in data:
         glist = iddgroups.iddtxt2grouplist(iddtxt)
-        result = iddgroups.group2commlst(idd_commlst, glist)
+        result = iddgroups.group2commlst(copy.deepcopy(idd_commlst), glist)
         assert result == groupcommlst
 
 


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_group2commlst` by removing state pollution in `idd_commlst` by making a deepcopy

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 $test_path`:

```
        for (groupcommlst,) in data:
            glist = iddgroups.iddtxt2grouplist(iddtxt)
            result = iddgroups.group2commlst(idd_commlst, glist)
>           assert result == groupcommlst
E           AssertionError: assert [[['group Non...t 7.0']], ...] == [[['group Non...t 7.0']], ...]
E             At index 0 diff: [['group None', 'idfobj Lead Input', 'group None', 'idfobj Lead Input']] != [['group None', 'idfobj Lead Input']]
E             Full diff:
E               [
E                [['group None',
E             +    'idfobj Lead Input',
E             +    'group None',
E                  'idfobj Lead Input']],...
E             
E             ...Full output truncated (60 lines hidden), use '-vv' to show
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
