### PR TITLE
Fix Issue #360

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,7 @@ Copyright (c) 2004, 2012-2016 Santosh Philip
 Copyright (c) 2012  Tuan Tran
 Copyright (c) 2014  Eric Allen Youngson
 Copyright (c) 2015-2016  Jamie Bull
+Copyright (c) 2021  Dimitris Mantas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
 The MIT License (MIT)
 
 Copyright (c) 2004, 2012-2016 Santosh Philip
-Copyright (c) 2012  Tuan Tran
-Copyright (c) 2014  Eric Allen Youngson
-Copyright (c) 2015-2016  Jamie Bull
+Copyright (c) 2012 Tuan Tran
+Copyright (c) 2014 Eric Allen Youngson
+Copyright (c) 2015-2016 Jamie Bull
 Copyright (c) 2021 Johan Tibell
-Copyright (c) 2021  Dimitris Mantas
+Copyright (c) 2021 Dimitris Mantas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,7 @@ Copyright (c) 2004, 2012-2016 Santosh Philip
 Copyright (c) 2012  Tuan Tran
 Copyright (c) 2014  Eric Allen Youngson
 Copyright (c) 2015-2016  Jamie Bull
+Copyright (c) 2021 Johan Tibell
 Copyright (c) 2021  Dimitris Mantas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/eppy/idfreader.py
+++ b/eppy/idfreader.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2012 Santosh Philip
+# Copyright (c) 2021  Dimitris Mantas
 # =======================================================================
 #  Distributed under the MIT License.
 #  (See accompanying file LICENSE or copy at

--- a/eppy/idfreader.py
+++ b/eppy/idfreader.py
@@ -40,6 +40,8 @@ def iddversiontuple(afile):
     except TypeError:
         fhandle = afile
     line1 = fhandle.readline()
+    if fhandle != afile:
+        fhandle.close()
     try:
         line1 = line1.decode("ISO-8859-2")
     except AttributeError:


### PR DESCRIPTION
This pull request addresses issue #360.

This seems to be a pretty important bug, since when simulating an .IDF file multiple times (see issue #364 for an example real use case), Python raises a relevant ResourceWarning.