### PR TITLE
Introduce Silent Verbose Mode (Issue #364)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,7 @@ Copyright (c) 2004, 2012-2016 Santosh Philip
 Copyright (c) 2012  Tuan Tran
 Copyright (c) 2014  Eric Allen Youngson
 Copyright (c) 2015-2016  Jamie Bull
+Copyright (c) 2021  Dimitris Mantas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
 The MIT License (MIT)
 
 Copyright (c) 2004, 2012-2016 Santosh Philip
-Copyright (c) 2012  Tuan Tran
-Copyright (c) 2014  Eric Allen Youngson
-Copyright (c) 2015-2016  Jamie Bull
+Copyright (c) 2012 Tuan Tran
+Copyright (c) 2014 Eric Allen Youngson
+Copyright (c) 2015-2016 Jamie Bull
 Copyright (c) 2021 Johan Tibell
-Copyright (c) 2021  Dimitris Mantas
+Copyright (c) 2021 Dimitris Mantas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,7 @@ Copyright (c) 2004, 2012-2016 Santosh Philip
 Copyright (c) 2012  Tuan Tran
 Copyright (c) 2014  Eric Allen Youngson
 Copyright (c) 2015-2016  Jamie Bull
+Copyright (c) 2021 Johan Tibell
 Copyright (c) 2021  Dimitris Mantas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/eppy/idfreader.py
+++ b/eppy/idfreader.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2012 Santosh Philip
+# Copyright (c) 2021  Dimitris Mantas
 # =======================================================================
 #  Distributed under the MIT License.
 #  (See accompanying file LICENSE or copy at

--- a/eppy/idfreader.py
+++ b/eppy/idfreader.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2012 Santosh Philip
-# Copyright (c) 2021  Dimitris Mantas
 # =======================================================================
 #  Distributed under the MIT License.
 #  (See accompanying file LICENSE or copy at

--- a/eppy/idfreader.py
+++ b/eppy/idfreader.py
@@ -40,8 +40,6 @@ def iddversiontuple(afile):
     except TypeError:
         fhandle = afile
     line1 = fhandle.readline()
-    if fhandle != afile:
-        fhandle.close()
     try:
         line1 = line1.decode("ISO-8859-2")
     except AttributeError:

--- a/eppy/runner/run_functions.py
+++ b/eppy/runner/run_functions.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2016 Jamie Bull
+# Copyright (c) 2021 Dimitris Mantas
 # =======================================================================
 #  Distributed under the MIT License.
 #  (See accompanying file LICENSE or copy at

--- a/eppy/runner/run_functions.py
+++ b/eppy/runner/run_functions.py
@@ -268,6 +268,7 @@ def run(
         Set verbosity of runtime messages (default: v)
             v: verbose
             q: quiet
+            s: silent
 
     ep_version: str
         EnergyPlus version, used to find install directory. Required if run() is
@@ -289,7 +290,7 @@ def run(
     """
     args = locals().copy()
     # get unneeded params out of args ready to pass the rest to energyplus.exe
-    verbose = args.pop("verbose")
+    verbose = args.pop("verbose").lower()
     idf = args.pop("idf")
     iddname = args.get("idd")
     if not isinstance(iddname, str):
@@ -356,6 +357,12 @@ def run(
             check_call(cmd)
         elif verbose == "q":
             check_call(cmd, stdout=open(os.devnull, "w"))
+        elif verbose == "s":
+            with open(os.devnull, "w") as null:
+                # Null can be written to, so this is not expected to affect issue #245.
+                check_call(cmd, stdout=null, stderr=null)
+        else:
+            raise ValueError("Unknown verbose mode: {}".format(verbose))
     except CalledProcessError:
         message = parse_error(tmp_err, output_dir)
         raise EnergyPlusRunError(message)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -481,6 +481,21 @@ class TestIDFRunner(object):
         out, _err = capfd.readouterr()
         assert len(out) > 0
 
+    def test_Verbose(self, capfd, test_idf):
+        """
+        End to end test of idf.run function with the version flag set True.
+        Fails on severe errors or unexpected/missing output files.
+        Fails if no output received from EnergyPlus.
+
+        """
+        test_idf.run(verbose="V", output_directory="run_outputs")
+        assert not has_severe_errors()
+        files = os.listdir("run_outputs")
+        self.expected_files.extend([])
+        assert set(files) == set(self.expected_files)
+        out, _err = capfd.readouterr()
+        assert len(out) > 0
+
     def test_quiet(self, capfd, test_idf):
         """
         End to end test of idf.run function with the version flag set True.
@@ -489,6 +504,49 @@ class TestIDFRunner(object):
 
         """
         test_idf.run(verbose="q", output_directory="run_outputs")
+        assert not has_severe_errors()
+        files = os.listdir("run_outputs")
+        self.expected_files.extend([])
+        assert set(files) == set(self.expected_files)
+        out, _err = capfd.readouterr()
+        assert len(out) == 0
+
+    def test_Quiet(self, capfd, test_idf):
+        """
+        End to end test of idf.run function with the version flag set True.
+        Fails on severe errors or unexpected/missing output files.
+        Fails if output received from EnergyPlus.
+
+        """
+        test_idf.run(verbose="Q", output_directory="run_outputs")
+        assert not has_severe_errors()
+        files = os.listdir("run_outputs")
+        self.expected_files.extend([])
+        assert set(files) == set(self.expected_files)
+        out, _err = capfd.readouterr()
+        assert len(out) == 0
+
+    def test_silent(self, capfd, test_idf):
+        """
+        End to end test of idf.run function with the version flag set True.
+        Fails on severe errors or unexpected/missing output files.
+        Fails if output received from EnergyPlus.
+        """
+        test_idf.run(verbose="s", output_directory="run_outputs")
+        assert not has_severe_errors()
+        files = os.listdir("run_outputs")
+        self.expected_files.extend([])
+        assert set(files) == set(self.expected_files)
+        out, _err = capfd.readouterr()
+        assert len(out) == 0
+
+    def test_Silent(self, capfd, test_idf):
+        """
+        End to end test of idf.run function with the version flag set True.
+        Fails on severe errors or unexpected/missing output files.
+        Fails if output received from EnergyPlus.
+        """
+        test_idf.run(verbose="S", output_directory="run_outputs")
         assert not has_severe_errors()
         files = os.listdir("run_outputs")
         self.expected_files.extend([])


### PR DESCRIPTION
Following up on issue santoshphilip#364, this commit intoduces a new silent (s) verbose mode for cases when no console ouput is required.

-------------
Change List
-------------
- Introduce a new silent (s) verbose mode, which sets both stdout and stderr to null.
- Convert user input regarding verbose mode to lower case increase user friendliness.
- Raise ValueError if an uknown verbose mode has been specified.

This commit was tested on Python 3.9 (Windows 10 64-bit) using PyCharm 2021.2.3 and E+ 9.0.1.