### PR TITLE
Update GitHub Actions to do Integration Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
     branches: 
-    - develop
 #         [main, master, develop]
   pull_request:
     branches: 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
     branches: 
+    - develop
 #         [main, master, develop]
   pull_request:
     branches: 
@@ -32,6 +33,13 @@ jobs:
         # --all-extras = install optional-dependencies e.g. [test], [dev], [all]
         # --dev      = install uv tool dev-dependencies (PEP 735 style)
 
+      - name: Install EnergyPlus
+        run: |
+          wget -q https://github.com/NatLabRockies/EnergyPlus/releases/download/v8.9.0/EnergyPlus-8.9.0-40101eaafd-Linux-x86_64.sh -O /tmp/eplus_install.sh
+          chmod +x /tmp/eplus_install.sh
+          echo "y" | sudo /tmp/eplus_install.sh
+
       - name: Run tests
+        env:
+          EPPY_INTEGRATION: "TRUE"
         run: uv run pytest
-        # You can also be more explicit:  uv run pytest tests/ --cov --cov-report=xml

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -43,7 +43,7 @@ def setversion(idf, newversion):
     not do_integration_tests(), reason="$EPPY_INTEGRATION env var not set"
 )
 class TestModeleditorIntegration:
-    def setup(self):
+    def setup_method(self):
         """Set the IDD and file paths, and make a copy of the original file."""
         iddfile = os.path.join(IDD_FILES, "Energy+V7_2_0.idd")
         IDF.setiddname(iddfile, testing=True)
@@ -58,7 +58,7 @@ class TestModeleditorIntegration:
         # make a copy of test file
         shutil.copy(self.origfile, self.startfile)
 
-    def teardown(self):
+    def teardown_method(self):
         """Clear up temp files so we don't accidentally check against them."""
         tempfiles = [self.startfile, self.saveasfile, self.copyfile]
         for f in tempfiles:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -136,13 +136,13 @@ class TestRunFunction(object):
 
     """Tests for simple running of EnergyPlus from Eppy."""
 
-    def setup(self):
+    def setup_method(self):
         """Tidy up just in case anything is left from previous test runs."""
         os.chdir(THIS_DIR)
         shutil.rmtree("test_results", ignore_errors=True)
         shutil.rmtree("run_outputs", ignore_errors=True)
 
-    def teardown(self):
+    def teardown_method(self):
         """Tidy up after tests."""
         os.chdir(THIS_DIR)
         shutil.rmtree("test_results", ignore_errors=True)
@@ -204,7 +204,7 @@ class TestIDFRunner(object):
 
     """Tests for running EnergyPlus from an IDF object."""
 
-    def setup(self):
+    def setup_method(self):
         """Tidy up anything left from previous runs. Get an IDF object to run."""
         shutil.rmtree(os.path.join(THIS_DIR, "run_outputs"), ignore_errors=True)
 
@@ -251,7 +251,7 @@ class TestIDFRunner(object):
             "eplus.rdd",
         ]
 
-    def teardown(self):
+    def teardown_method(self):
         """Destroy temp dir, reset working directory, destroy outputs."""
         os.chdir(THIS_DIR)
         shutil.rmtree("run_outputs", ignore_errors=True)
@@ -610,7 +610,7 @@ class TestMultiprocessing(object):
 
     """Tests for running multiple EnergyPlus jobs simultaneously."""
 
-    def setup(self):
+    def setup_method(self):
         """Clear out any results from previous tests."""
         os.chdir(THIS_DIR)
         shutil.rmtree("multirun_outputs", ignore_errors=True)
@@ -629,7 +629,7 @@ class TestMultiprocessing(object):
             "sqlite.err",
         ]
 
-    def teardown(self):
+    def teardown_method(self):
         """Remove the multiprocessing results folders."""
         for results_dir in glob("results_*"):
             shutil.rmtree(results_dir)


### PR DESCRIPTION
Hello @santoshphilip, just addressing Issue #455. 

I've added an installation of EnergyPlus-8.9.0 and flipped the EPPY_INTEGRATION env var in tests.yml.

I also had to edit test_runner.py and test_integration.py (renaming methods for pytest 9 compatibility)

I also noticed the delete_oldworkflows folder contains a previous attempt at EnergyPlus CI. The new workflow in tests.yml supersedes it. Should this folder be removed?